### PR TITLE
fix structure block

### DIFF
--- a/frontend/skin/default/blocks/block.structure.tpl
+++ b/frontend/skin/default/blocks/block.structure.tpl
@@ -12,7 +12,7 @@
 	{component 'nav'
 		name       = 'pages_tree'
 		classes    = 'actionbar-item-link'
-		activeItem = $oCurrentPage->getUrlFull()
+		activeItem = ($oCurrentPage) ? $oCurrentPage->getUrlFull() : false
 		mods       = 'stacked pills'
 		items      = $aItems}
 {/capture}


### PR DESCRIPTION
Для возможности вызывать блок на других страницах сайта

```
$config['block']['rule_blog_page_structure'] = [
	'action' => [ 'index', 'blog', 'people', ... ],
	'blocks' => [
		'right' => [
			'structure' => [ 'params' => [ 'plugin' => 'page' ] ]
		]
	]
];
```